### PR TITLE
Archimage 4: use hardware acceleration

### DIFF
--- a/archimage-cli
+++ b/archimage-cli
@@ -153,7 +153,7 @@ _add_dependences() {
 _include_all_dependences() {
 	echo "◆ Automatic library checking should be more than enough. However..."
 	read -r -ep "  DO YOU WANT TO INCLUDE ALL DEPENDENCES? THE PACKAGE MAY BE BLOATED (y,N) " yn
-    	if echo "$yn" | grep -q "^y"; then
+    	if echo "$yn" | grep -qi "^y"; then
     		sed -i 's/#rsync -av/rsync -av/g' ./"$APP"-junest.sh
 	fi
 }
@@ -161,7 +161,7 @@ _include_all_dependences() {
 # Allow Nvidia check in the final AppImage
 _enable_nvidia() {
 	read -r -ep "◆ DO YOU WANT TO ENABLE HARDWARE ACCELERATION FOR NVIDIA USERS? (y,N) " yn
-    	if echo "$yn" | grep -q "^y"; then
+    	if echo "$yn" | grep -qi "^y"; then
     		sed -i 's/NVIDIA_ON=0/NVIDIA_ON=1/g' ./"$APP"-junest.sh
 	fi
 }
@@ -177,21 +177,21 @@ Choose \"N\" or leave blank instead to continue customization (RECOMMENDED).
 _enable_chaoticaur() {
 	echo "$DIVIDING_LINE"
 	read -r -ep "◆ DO YOU WANT TO ENABLE CHAOTIC-AUR (y,N)? " yn
-    	if echo "$yn" | grep -q "^y"; then
+    	if echo "$yn" | grep -qi "^y"; then
 		sed -i 's/###_enable_chaoticaur/_enable_chaoticaur/g' ./"$APP"-junest.sh
 	fi
 }
 
 _enable_basicstuff() {
 	read -r -ep "◆ DO YOU WANT TO INCLUDE BINUTILS AND GZIP (y,N)? " yn
-    	if echo "$yn" | grep -q "^y"; then
+    	if echo "$yn" | grep -qi "^y"; then
 		sed -i 's/#BASICSTUFF/BASICSTUFF/g' ./"$APP"-junest.sh
 	fi
 }
 
 _enable_compilers(){
 	read -r -ep "◆ DO YOU WANT TO INCLUDE THE BASE-DEVEL PACKAGE AND COMPILE FROM AUR (y,N)? " yn
-    	if echo "$yn" | grep -q "^y"; then
+    	if echo "$yn" | grep -qi "^y"; then
 		sed -i 's/#COMPILERS/COMPILERS/g' ./"$APP"-junest.sh
 		sed -i '/-- gpg --keyserver/ s/^#*//' ./"$APP"-junest.sh
 	fi
@@ -223,21 +223,21 @@ _keywords_to_save_in_usr_lib() {
 
 _include_swrast() {
 	read -r -ep "◆ DO YOU WANT TO INCLUDE THE /usr/lib/dri/swrast_dri.so DRIVER (y,N)? " yn
-    	if echo "$yn" | grep -q "^y"; then
+    	if echo "$yn" | grep -qi "^y"; then
 		sed -i 's/#_include_swrast_dri/_include_swrast_dri/g' ./"$APP"-junest.sh
 	fi
 }
 
 _include_audio_keywords() {
 	read -r -ep "◆ DO YOU WISH TO ADD KEYWORDS IN /usr/lib TO ENABLE THE AUDIO (y,N)?" yn
-	if echo "$yn" | grep -q "^y"; then
+	if echo "$yn" | grep -qi "^y"; then
 		sed -i 's/LIBSAVED="/LIBSAVED="alsa jack pipewire pulse /g' ./"$APP"-junest.sh
 	fi
 }
 
 _include_internet_keywords() {
 	read -r -ep "◆ I RECOMMEND TO USE CA-CERTIFICATES TRYING TO ENABLE THE INTERNET $(echo -e '\n  DO YOU WISH TO ADD IT INTO THE SCIPT (y,N)?') " yn
-	if echo "$yn" | grep -q "^y"; then
+	if echo "$yn" | grep -qi "^y"; then
 		sed -i 's/DEPENDENCES="/DEPENDENCES="ca-certificates /g'  ./"$APP"-junest.sh
 		sed -i 's/BINSAVED="/BINSAVED="certificates /g'  ./"$APP"-junest.sh
 		sed -i 's/#_binlibs/_binlibs/g' ./"$APP"-junest.sh
@@ -251,7 +251,7 @@ _include_internet_keywords() {
 
 _select_libraries() {
 	read -r -ep "◆ DO YOU WISH TO SELECT LIBRARIES TO SAVE (y,N)?" yn
-	if echo "$yn" | grep -q "^y"; then
+	if echo "$yn" | grep -qi "^y"; then
 		sed -i 's/#_binlibs/_binlibs/g' ./"$APP"-junest.sh
 		sed -i 's/#_liblibs/_liblibs/g' ./"$APP"-junest.sh
 		sed -i 's/#_mvlibs/_mvlibs/g' ./"$APP"-junest.sh
@@ -300,7 +300,7 @@ case "$1" in
 			echo "$DIVIDING_LINE"
 			echo "$STANDARD_CONFIGURATION_MSG" | _fit | sed "s/^/ /g; s/  ◆/◆/g"
 			read -r -ep "  DO YOU WISH TO USE A STANDARD CONFIGURATION (y,N)? " yn
-    			if echo "$yn" | grep -q "^y"; then
+    			if echo "$yn" | grep -qi "^y"; then
 				sed -i 's/#_binlibs/_binlibs/g' ./"$APP"-junest.sh # CHECK LIBRARIES RELATED TO BINARIES
 				sed -i 's/#_liblibs/_liblibs/g' ./"$APP"-junest.sh # CHECK LIBRARIES RELATED TO OTHER LIBRARIES
 				sed -i 's/#_mvlibs/_mvlibs/g' ./"$APP"-junest.sh # MV ALL LIBRARIES SAVED IN THE COMMANDS ABOVE AND BELOW

--- a/archimage-cli
+++ b/archimage-cli
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="3.5"
+VERSION="4"
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 ARCHIMAGE_REPO="https://raw.githubusercontent.com/ivan-hc/ArchImage/main"
@@ -158,6 +158,14 @@ _include_all_dependences() {
 	fi
 }
 
+# Allow Nvidia check in the final AppImage
+_enable_nvidia() {
+	read -r -ep "◆ DO YOU WANT TO ENABLE HARDWARE ACCELERATION FOR NVIDIA USERS? (y,N) " yn
+    	if echo "$yn" | grep -q "^y"; then
+    		sed -i 's/NVIDIA_ON=0/NVIDIA_ON=1/g' ./"$APP"-junest.sh
+	fi
+}
+
 # Start configuration
 STANDARD_CONFIGURATION_MSG="◆ Choose to finish using a standard configuration with the bare minimum or continue by customizing the script as much as possible (default).
 The standard configuration includes a package availability check in the Arch User Repository (if so, enable AUR and installs \"binutils\", \"gzip\" and \"basedevel\", all of them are only required to compile from and will not be included in the AppImage package), the AUR is enabled, installs \"ca-certificates\", includes keywords for the internet connections and audio trying to enable them.
@@ -287,6 +295,8 @@ case "$1" in
 			_add_dependences
 			echo "$DIVIDING_LINE"
 			_include_all_dependences
+			echo "$DIVIDING_LINE"
+			_enable_nvidia
 			echo "$DIVIDING_LINE"
 			echo "$STANDARD_CONFIGURATION_MSG" | _fit | sed "s/^/ /g; s/  ◆/◆/g"
 			read -r -ep "  DO YOU WISH TO USE A STANDARD CONFIGURATION (y,N)? " yn

--- a/sample-junest.sh
+++ b/sample-junest.sh
@@ -203,6 +203,33 @@ function _create_AppRun() {
 	export PATH=$HERE/.local/share/junest/bin/:$PATH
 	mkdir -p $HOME/.cache
 
+	[ -z "$NVIDIA_ON" ] && NVIDIA_ON=1
+	if [ "$NVIDIA_ON" = 1 ]; then
+	  DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+	  CONTY_DIR="${DATADIR}/Conty/overlayfs_shared"
+	  CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+	  [ -f /sys/module/nvidia/version ] && nvidia_driver_version="$(cat /sys/module/nvidia/version)"
+	  [ -f "${CONTY_DIR}"/nvidia/current-nvidia-version ] && nvidia_driver_conty="$(cat "${CONTY_DIR}"/nvidia/current-nvidia-version)"
+	  if [ "${nvidia_driver_version}" != "${nvidia_driver_conty}" ]; then
+	     if command -v curl >/dev/null 2>&1; then
+	        if ! curl --output /dev/null --silent --head --fail https://github.com 1>/dev/null; then
+	          notify-send "You are offline, cannot use Nvidia drivers"
+	        else
+	          notify-send "Configuring Nvidia drivers for this AppImage..."
+	          mkdir -p "${CACHEDIR}" && cd "${CACHEDIR}" || exit 1
+	          curl -Ls "https://raw.githubusercontent.com/ivan-hc/ArchImage/main/nvidia-junest.sh" > nvidia-junest.sh
+	          chmod a+x ./nvidia-junest.sh && ./nvidia-junest.sh
+	        fi
+	     else
+	        notify-send "Missing \"curl\" command, cannot use Nvidia drivers"
+	        echo "You need \"curl\" to download this script"
+	     fi
+	  fi
+	  [ -d "${CONTY_DIR}"/up/usr/bin ] && export PATH="${PATH}":"${CONTY_DIR}"/up/usr/bin:"${PATH}"
+	  [ -d "${CONTY_DIR}"/up/usr/lib ] && export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}":"${CONTY_DIR}"/up/usr/lib:"${LD_LIBRARY_PATH}"
+	  [ -d "${CONTY_DIR}"/up/usr/share ] && export XDG_DATA_DIRS="${XDG_DATA_DIRS}":"${CONTY_DIR}"/up/usr/share:"${XDG_DATA_DIRS}"
+	fi
+
 	BINDINGS=""
 	bind_files="/etc/resolv.conf /etc/hosts /etc/nsswitch.conf /etc/passwd /etc/group /etc/machine-id /etc/asound.conf /etc/localtime "
 	for f in $bind_files; do [ -f "$f" ] && BINDINGS=" $BINDINGS --bind=$f"; done
@@ -525,4 +552,4 @@ if test -f ./*.AppImage; then
 	rm -R -f ./*archimage*.AppImage
 fi
 ARCH=x86_64 ./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 ./$APP.AppDir
-mv ./*AppImage ./"$(cat ./"$APP".AppDir/*.desktop | grep 'Name=' | head -1 | cut -c 6- | sed 's/ /-/g')"_"$VERSION"-archimage3.4.4-2.2-x86_64.AppImage
+mv ./*AppImage ./"$(cat ./"$APP".AppDir/*.desktop | grep 'Name=' | head -1 | cut -c 6- | sed 's/ /-/g')"_"$VERSION"-archimage4-x86_64.AppImage

--- a/sample-junest.sh
+++ b/sample-junest.sh
@@ -203,7 +203,7 @@ function _create_AppRun() {
 	export PATH=$HERE/.local/share/junest/bin/:$PATH
 	mkdir -p $HOME/.cache
 
-	[ -z "$NVIDIA_ON" ] && NVIDIA_ON=1
+	[ -z "$NVIDIA_ON" ] && NVIDIA_ON=0
 	if [ "$NVIDIA_ON" = 1 ]; then
 	  DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 	  CONTY_DIR="${DATADIR}/Conty/overlayfs_shared"

--- a/sample-next-junest.sh
+++ b/sample-next-junest.sh
@@ -202,6 +202,33 @@ function _create_AppRun() {
 	export JUNEST_HOME=$HERE/.junest
 	export PATH=$PATH:$HERE/.local/share/junest/bin
 
+	[ -z "$NVIDIA_ON" ] && NVIDIA_ON=1
+	if [ "$NVIDIA_ON" = 1 ]; then
+	  DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+	  CONTY_DIR="${DATADIR}/Conty/overlayfs_shared"
+	  CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+	  [ -f /sys/module/nvidia/version ] && nvidia_driver_version="$(cat /sys/module/nvidia/version)"
+	  [ -f "${CONTY_DIR}"/nvidia/current-nvidia-version ] && nvidia_driver_conty="$(cat "${CONTY_DIR}"/nvidia/current-nvidia-version)"
+	  if [ "${nvidia_driver_version}" != "${nvidia_driver_conty}" ]; then
+	     if command -v curl >/dev/null 2>&1; then
+	        if ! curl --output /dev/null --silent --head --fail https://github.com 1>/dev/null; then
+	          notify-send "You are offline, cannot use Nvidia drivers"
+	        else
+	          notify-send "Configuring Nvidia drivers for this AppImage..."
+	          mkdir -p "${CACHEDIR}" && cd "${CACHEDIR}" || exit 1
+	          curl -Ls "https://raw.githubusercontent.com/ivan-hc/ArchImage/main/nvidia-junest.sh" > nvidia-junest.sh
+	          chmod a+x ./nvidia-junest.sh && ./nvidia-junest.sh
+	        fi
+	     else
+	        notify-send "Missing \"curl\" command, cannot use Nvidia drivers"
+	        echo "You need \"curl\" to download this script"
+	     fi
+	  fi
+	  [ -d "${CONTY_DIR}"/up/usr/bin ] && export PATH="${PATH}":"${CONTY_DIR}"/up/usr/bin:"${PATH}"
+	  [ -d "${CONTY_DIR}"/up/usr/lib ] && export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}":"${CONTY_DIR}"/up/usr/lib:"${LD_LIBRARY_PATH}"
+	  [ -d "${CONTY_DIR}"/up/usr/share ] && export XDG_DATA_DIRS="${XDG_DATA_DIRS}":"${CONTY_DIR}"/up/usr/share:"${XDG_DATA_DIRS}"
+	fi
+
 	BINDS=" --dev-bind /dev /dev \
 		--ro-bind /sys /sys \
 		--bind-try /tmp /tmp \
@@ -531,4 +558,4 @@ if test -f ./*.AppImage; then
 	rm -R -f ./*archimage*.AppImage
 fi
 ARCH=x86_64 ./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 ./$APP.AppDir
-mv ./*AppImage ./"$(cat ./"$APP".AppDir/*.desktop | grep 'Name=' | head -1 | cut -c 6- | sed 's/ /-/g')"_"$VERSION"-archimage3.4.4-2.2-x86_64.AppImage
+mv ./*AppImage ./"$(cat ./"$APP".AppDir/*.desktop | grep 'Name=' | head -1 | cut -c 6- | sed 's/ /-/g')"_"$VERSION"-archimage4-x86_64.AppImage

--- a/sample-next-junest.sh
+++ b/sample-next-junest.sh
@@ -202,7 +202,7 @@ function _create_AppRun() {
 	export JUNEST_HOME=$HERE/.junest
 	export PATH=$PATH:$HERE/.local/share/junest/bin
 
-	[ -z "$NVIDIA_ON" ] && NVIDIA_ON=1
+	[ -z "$NVIDIA_ON" ] && NVIDIA_ON=0
 	if [ "$NVIDIA_ON" = 1 ]; then
 	  DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 	  CONTY_DIR="${DATADIR}/Conty/overlayfs_shared"


### PR DESCRIPTION
If you are an Nvidia user, for the JuNest-based build, hardware accelleration is provided by [Conty](https://github.com/Kron4ek/Conty). At first start it will install Nvidia drivers locally to allow the builtin Arch Linux container the use of hardware accelleration.

This release will merge the flexibility of JuNest with the power of Conty.

Fix https://github.com/ivan-hc/ArchImage/issues/20